### PR TITLE
Smooth out the long jump

### DIFF
--- a/Assets/Scenes/PlayerStaging.unity
+++ b/Assets/Scenes/PlayerStaging.unity
@@ -283,6 +283,7 @@ GameObject:
   - component: {fileID: 663478326}
   - component: {fileID: 663478327}
   - component: {fileID: 663478328}
+  - component: {fileID: 663478329}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -490,7 +491,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 663478317}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a21e4efb80b7c9249832f2b1ff85651c, type: 3}
   m_Name: 
@@ -501,6 +502,28 @@ MonoBehaviour:
   jumpCount: 2
   dustEffectPrefab: {fileID: 4298217138393534313, guid: aa7f0ad2f4c45854faa5cd02325f81a7,
     type: 3}
+--- !u!114 &663478329
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 663478317}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e1d3ce8814e405c4eb19bce2fe31f8a4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  inputButtons: 05000000
+  jumpSpeed: 150
+  jumpDelay: 0.1
+  jumpCount: 2
+  dustEffectPrefab: {fileID: 4298217138393534313, guid: aa7f0ad2f4c45854faa5cd02325f81a7,
+    type: 3}
+  longJumpDelay: 0.15
+  longJumpMultiplier: 1.2
+  canLongJump: 0
+  isLongJumping: 0
 --- !u!1 &1392985564
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Behaviors/LongJump.cs
+++ b/Assets/Scripts/Behaviors/LongJump.cs
@@ -31,8 +31,8 @@ public class LongJump : Jump
 
         if (canLongJump && !collisionState.standing && holdTime > longJumpDelay){
             var vel = body2D.velocity;
-            body2D.velocity = new Vector2 (vel.x, jumpSpeed * longJumpMultiplier);
-            canLongJump = false;
+            body2D.velocity = new Vector2 (vel.x, jumpSpeed * longJumpMultiplier); // this multiplier can be altered in the inspector.
+            canLongJump = false;                                                   // as it is, it's too jarring. figure out a way to smooth this
             isLongJumping = true;
         }
     }


### PR DESCRIPTION
` var vel = body2D.velocity;
            body2D.velocity = new Vector2 (vel.x, jumpSpeed * longJumpMultiplier);`

This multiplier value can be altered by the inspector. As it is now, long jump is too jarring. I need to figure out a way to smooth this out. I should see how they handle it in the Corgi Engine.

![longjump](https://user-images.githubusercontent.com/11033188/60774920-71e26f80-a0e9-11e9-85b4-fd9268fa0f49.gif)
